### PR TITLE
Fixed some bugs in the docs side bar

### DIFF
--- a/sunpy_sphinx_theme/sunpy/static/style.css
+++ b/sunpy_sphinx_theme/sunpy/static/style.css
@@ -206,7 +206,7 @@ p.whatsnew {
 /* Sidebar */
 
 #sidebar {
-  z-index: 100;
+  z-index: 0;
 }
 
 .bs-sidenav {
@@ -216,7 +216,7 @@ p.whatsnew {
   margin-bottom: 50px;
   overflow-x: hidden;
   overflow-y: scroll;
-  position: fixed;
+  position: relative;
   width: 300px;
   max-height: 80%;
   border-left: 3px solid #fe7900;


### PR DESCRIPTION
For example [here](http://docs.sunpy.org/en/stable/guide/installation/advanced.html#troubleshooting) the whole side bar is not visible while scrolling down.

![screenshot 2017-10-19 10 33 45](https://user-images.githubusercontent.com/16035442/31754993-0af01c28-b4b9-11e7-9890-5850c3a59965.png)


Also since z index value was 100, it was kind of over written over the bottom tag lines `© 2017, The SunPy Community`


Changes now looks like this

![screenshot 2017-10-19 10 35 32](https://user-images.githubusercontent.com/16035442/31755022-49d67b9e-b4b9-11e7-9807-43150819e40d.png)

@Cadair @nabobalis reviews
