### PR TITLE
Add information about python version and license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,13 @@ setup(
     ],
     packages=['sunpy_sphinx_theme'],
     include_package_data=True,
+    license='2-clause BSD',
+    classifiers=[
+        'Intended Audience :: Developers',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+        'Operating System :: OS Independent',
+        'License :: OSI Approved :: BSD License',
+    ],
 )


### PR DESCRIPTION
Because python version and license is not shown on [libraries.io](https://libraries.io/github/sunpy/sunpy) and [pyup](https://pyup.io/account/repos/github/sunpy/sunpy/)