### PR TITLE
Improve link contrast against white background

### DIFF
--- a/sunpy_sphinx_theme/sunpy/static/sunpy_style.css
+++ b/sunpy_sphinx_theme/sunpy/static/sunpy_style.css
@@ -20,7 +20,7 @@ h4 {
 }
 
 a {
-  color: #fe7900;
+  color: #bd5b00;
 }
 
 a.fn-backref {


### PR DESCRIPTION
Part of #94. All I've done is modify the contrast between the old link colour and white to 4.5, as a recommended minimum. This means the link colour is sort of dark brown now, which might not be optimal? The other option is to go blue for all links, instead of some being blue and some being orange.