### PR TITLE
Reduce toc depth

### DIFF
--- a/sunpy_sphinx_theme/sunpy/docsidebar.html
+++ b/sunpy_sphinx_theme/sunpy/docsidebar.html
@@ -1,4 +1,4 @@
-{% set toctree = toctree(maxdepth=4, collapse=True, includehidden=True) %}
+{% set toctree = toctree(maxdepth=2, collapse=True, includehidden=True) %}
 {% if toctree %}
 {% if logo %}
 <div class="sidelogo">


### PR DESCRIPTION
This reduces the table of content depth in the sidebar. Fixes https://github.com/sunpy/sunpy/issues/4501, definitely open for discussion. I think this makes both the gallery and the API docs look better, and I don't think there are any places where we need to go above level 2 (but maybe I missed something). Other option would be to just do this for the gallery perhaps?

Before/after:
![Screenshot 2020-09-25 at 12 06 53](https://user-images.githubusercontent.com/6197628/94260179-9bbec680-ff27-11ea-8673-723346ac1617.png) ![Screenshot 2020-09-25 at 12 07 07](https://user-images.githubusercontent.com/6197628/94260198-a4170180-ff27-11ea-9daa-263c795390ba.png)


![Screenshot 2020-09-25 at 12 05 11](https://user-images.githubusercontent.com/6197628/94260035-5f8b6600-ff27-11ea-91db-b5ede8ebaa5e.png) ![Screenshot 2020-09-25 at 12 06 04](https://user-images.githubusercontent.com/6197628/94260117-7df16180-ff27-11ea-8081-31e9a9555dc5.png)



