### PR TITLE
Pin sphinx to < 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,10 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
 ]
 requires-python = ">=3.7"
-dependencies = ["sphinx-bootstrap-theme"]
+dependencies = [
+  "sphinx-bootstrap-theme",
+  "sphinx<6"
+]
 
 [project.entry-points]
 "sphinx.html_themes" = { sunpy = "sunpy_sphinx_theme" }


### PR DESCRIPTION
As per https://github.com/sunpy/sunkit-instruments/issues/101#issue-1627343068, explicitly pin to sphinx < 6. Because of the dependency on `sphinx-design` in the test package, none of the tests actually test here with sphinx >= 6 at the moment anyway.