### PR TITLE
Fix RTD flyout positioning on mobile by making the sidebar have a fixed bottom position

### DIFF
--- a/src/sunpy_sphinx_theme/theme/sunpy/static/sunpy_style.css
+++ b/src/sunpy_sphinx_theme/theme/sunpy/static/sunpy_style.css
@@ -243,17 +243,25 @@ html[data-theme="light"] .bd-sidebar-primary .theme-switch-button span {
 }
 
 /* Sidebar */
+/* Left hand sidebar */
 .bd-sidebar-primary {
   background-color: var(--sst-sidebar-background-color);
   max-height: calc(100vh - var(--pst-header-height));
   flex-basis: 22%;
   border-right-width: 3px;
   border-right-color: var(--sst-accent-color-bright);
-  top: var(--pst-header-height);
 }
 
+/* Both left and right sidebars */
+.bd-sidebar-primary,
 .bd-sidebar-secondary {
+  /* Reduce the top padding */
+  padding-top: 1rem;
+  /* Because we have a fixed header, we make the sidebar(s) a dynamic height with a */
+  /* fixed top and bottom. */
+  height: auto;
   top: var(--pst-header-height);
+  bottom: 0;
 }
 
 .bd-sidebar a.navbar-brand {
@@ -276,6 +284,11 @@ img.logo__image {
   height: var(--pst-header-height);
 }
 
+.bd-sidebar-primary .sidebar-primary-items__end {
+  /* Disable the bottom margin in the end sidebar Section */
+  margin-bottom: 0;
+}
+
 /* RTD Flyout tweaks */
 .bd-sidebar-primary div#rtd-footer-container .rst-other-versions input {
   color: var(--pst-color-primary);
@@ -290,12 +303,6 @@ img.logo__image {
 .rst-versions .rst-other-versions hr {
   margin: 5px 0;
   border-top-color: var(--pst-color-border);
-}
-
-/* Bizzarely having a minimum height here fixes the permanent appearance of the */
-/* sidebar scrollbar */
-#rtd-footer-container {
-  min-height: 1rem;
 }
 
 /* Revert the flyout footer to the RTD font size */


### PR DESCRIPTION
This is the worst, I am remote debugging on mobile when I have to have the test builds on rtd.

Also fixes #240 