### PR TITLE
Update Mobile Menu Icon Color

### DIFF
--- a/src/sunpy_sphinx_theme/theme/sunpy/static/sunpy_style.css
+++ b/src/sunpy_sphinx_theme/theme/sunpy/static/sunpy_style.css
@@ -75,8 +75,8 @@ html[data-theme="light"] {
   --pst-color-link-hover: var(--sst-accent-color-muted);
   --pst-color-link: var(--sst-accent-color-bright);
   --pst-color-on-background: #fff;
-  --pst-color-on-surface: #222832;
-  --pst-color-primary-bg: #d0ecf1;
+  --pst-color-on-surface: #ffffff;
+  --pst-color-primary-bg: #ffffff;
   --pst-color-primary: var(--sst-accent-color-bright);
   --pst-color-secondary-bg: #e0c7ff;
   --pst-color-secondary: var(--sst-accent-color-bright);


### PR DESCRIPTION
## PR Description

This pull request changes the color of the mobile menu icon to improve visibility. The previous color was dark when toggled, making it hard to distinguish against certain backgrounds.
The following changes have been made:

Updated the color of the mobile menu icon to:
line 78 --pst-color-on-surface: #ffffff;
line 79 --pst-color-primary-bg: #ffffff;