### PR TITLE
Update Sidebar Toggle Button Styling

### DIFF
--- a/src/sunpy_sphinx_theme/theme/sunpy/static/sunpy_style.css
+++ b/src/sunpy_sphinx_theme/theme/sunpy/static/sunpy_style.css
@@ -196,6 +196,14 @@ html[data-theme="dark"] div.graphviz > object.inheritance {
   padding-left: 0.6rem;
 }
 
+button.sidebar-toggle {
+  font-size: var(--pst-font-size-icon);
+  color: #ffffff;
+  margin-bottom: 0;
+  background-color: inherit;
+  padding: 0.5rem;
+}
+
 .bd-header ul.navbar-nav > li.nav-item.dropdown > .dropdown-toggle {
   color: var(--sst-header-text);
 }

--- a/src/sunpy_sphinx_theme/theme/sunpy/static/sunpy_style.css
+++ b/src/sunpy_sphinx_theme/theme/sunpy/static/sunpy_style.css
@@ -253,7 +253,7 @@ html[data-theme="light"] .bd-sidebar-primary .theme-switch-button span {
 
 .bd-header label.sidebar-toggle {
   padding-bottom: 0;
-  color: var(--sst-header-text);
+  color:  #ffffff;
 }
 
 /* Style the dropdown from the top nav */


### PR DESCRIPTION
This pull request adds custom styling for the .sidebar-toggle button. The main focus is to improve the visual appearance and layout of the sidebar toggle button
```
button.sidebar-toggle {
  font-size: var(--pst-font-size-icon);
  color: #ffffff;
  margin-bottom: 0;
  background-color: inherit;
  padding: 0.5rem;
}
```
