### PR TITLE
Adding citing sunpy to navbar 

### DIFF
--- a/src/sunpy_sphinx_theme/__init__.py
+++ b/src/sunpy_sphinx_theme/__init__.py
@@ -59,7 +59,6 @@ def default_navbar():
         ("Contribute", "contribute/", 2),
         ("Blog", "blog/", 2),
         ("Citing SunPy", "https://docs.sunpy.org/en/stable/citation.html", 3),
-
     ]
 
 

--- a/src/sunpy_sphinx_theme/__init__.py
+++ b/src/sunpy_sphinx_theme/__init__.py
@@ -54,11 +54,11 @@ def default_navbar():
                 ("radiospectra", "https://docs.sunpy.org/projects/radiospectra/", 3),
             ],
         ),
-        ("Affiliated Packages", "affiliated/", 2),
+        ("Packages", "affiliated/", 2),
         ("Get Help", "help/", 2),
         ("Contribute", "contribute/", 2),
         ("Blog", "blog/", 2),
-        ("Citing SunPy", "https://docs.sunpy.org/en/stable/citation.html", 3),
+        ("Cite SunPy", "https://docs.sunpy.org/en/stable/citation.html", 3),
     ]
 
 

--- a/src/sunpy_sphinx_theme/__init__.py
+++ b/src/sunpy_sphinx_theme/__init__.py
@@ -58,6 +58,8 @@ def default_navbar():
         ("Get Help", "help/", 2),
         ("Contribute", "contribute/", 2),
         ("Blog", "blog/", 2),
+        ("Citing SunPy", "https://docs.sunpy.org/en/stable/citation.html", 3),
+
     ]
 
 


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy.org/issues/438 and adds an easy link to cite sunpy to the navbar