### PR TITLE
Support pydata-sphinx-theme 0.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-  "pydata-sphinx-theme~=0.17",
+  "pydata-sphinx-theme>=0.17,<0.19",
   "sphinxext-opengraph>=0.13",
   "sphinx>=7.3.0"
 ]


### PR DESCRIPTION
Testing with rc2 shows no further problems after #320 so relax our version pinning to allow 0.17 or 0.18.

The alternative to this is to wait for 0.18 final and just pin to that?