### PR TITLE
try to respect `sphinx_gallery_thumbnail_number` for link unfurling

### DIFF
--- a/examples/example_template.py
+++ b/examples/example_template.py
@@ -10,11 +10,13 @@ thing>. Include links to referenced packages like this: `sunpy.io.fits` to
 show the sunpy.io.fits or like this `~sunpy.io.fits` to show just 'fits'
 """
 
+# sphinx_gallery_thumbnail_number = 2
+
 ###########################################################################
 # If you have multiple plots in your example, Sphinx will use the first
 # plot for the thumbnail by default. You can set which plot is used as the
 # thumbnail by adding the following comment to your file.
-# ``#sphinx_gallery_thumbnail_number = X``
+# ``# sphinx_gallery_thumbnail_number = X``
 # where ``X`` is the figure number you want (from 1).
 
 import matplotlib.pyplot as plt

--- a/examples/section/example_template_subsection.py
+++ b/examples/section/example_template_subsection.py
@@ -16,7 +16,7 @@ show the sunpy.io.fits or like this `~sunpy.io.fits` to show just 'fits'
 # If you have multiple plots in your example, Sphinx will use the first
 # plot for the thumbnail by default. You can set which plot is used as the
 # thumbnail by adding the following comment to your file.
-# ``#sphinx_gallery_thumbnail_number = X``
+# ``# sphinx_gallery_thumbnail_number = X``
 # where ``X`` is the figure number you want (from 1).
 
 import matplotlib.pyplot as plt

--- a/src/sunpy_sphinx_theme/__init__.py
+++ b/src/sunpy_sphinx_theme/__init__.py
@@ -122,6 +122,28 @@ def update_html_context(app: Sphinx, pagename: str, templatename: str, context, 
     context["sst_pathto"] = partial(sst_pathto, context)
 
 
+def _get_sphinx_gallery_thumbnail(doctree):
+    """
+    Return the generated Sphinx-Gallery thumbnail for an example page.
+    """
+    source = doctree.get("source")
+    if not source:
+        return None
+
+    source_path = Path(source)
+    thumbnail_dir = source_path.parent / "images" / "thumb"
+    if not thumbnail_dir.is_dir():
+        return None
+
+    # Reuse the thumbnail Sphinx-Gallery already picked for this page.
+    thumbnails = sorted(thumbnail_dir.glob(f"sphx_glr_{source_path.stem}_thumb.*"))
+    for thumbnail in thumbnails:
+        if thumbnail.suffix.lower() in SPHINX_GALLERY_IMAGE_EXTENSIONS:
+            return thumbnail
+
+    return None
+
+
 def update_opengraph_context(app: Sphinx, pagename: str, templatename: str, context, doctree) -> None:  # NOQA: ARG001
     """
     Add Sphinx-Gallery images to the Open Graph metadata context.
@@ -133,6 +155,13 @@ def update_opengraph_context(app: Sphinx, pagename: str, templatename: str, cont
     if "og:image" in metadata:
         return
 
+    # Prefer the user defined generated gallery thumbnail when one exists.
+    if thumbnail := _get_sphinx_gallery_thumbnail(doctree):
+        metadata["og:image"] = posixpath.join(app.builder.imagedir, thumbnail.name)
+        context["meta"] = metadata
+        return
+
+    # Fall back to the first gallery image
     for node in doctree.findall():
         if node.__class__.__name__ != "imgsgnode" or not node.get("uri"):
             continue


### PR DESCRIPTION
I do not like it when I use the word "try" in a commit message, AI helped write the private function in use here when I failed.

I am just gonna see what links look like when RTD succeeds


AI tools were used for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [ ] No AI tools were used

