### PR TITLE
Pin RTD search query to current version

### DIFF
--- a/src/sunpy_sphinx_theme/theme/sunpy/static/js/rtd_enhanced_search.js
+++ b/src/sunpy_sphinx_theme/theme/sunpy/static/js/rtd_enhanced_search.js
@@ -34,6 +34,18 @@
 
 */
 /*jshint esversion: 6 */
+// Capture the current RTD version so search results stay on the version
+// the user is reading. Without this, the v3 search API defaults to the
+// project's default version (usually stable) and results link elsewhere.
+let _rtdVersion = null;
+document.addEventListener("readthedocs-addons-data-ready", function (event) {
+  try {
+    _rtdVersion = event.detail.data().versions.current.slug;
+  } catch (e) {
+    _rtdVersion = null;
+  }
+});
+
 (function (root) {
   function ready(fn) {
     if (document.readyState != "loading") fn();
@@ -248,7 +260,8 @@
       } else {
         url =
           (debug ? "https://corsproxy.io/?https://readthedocs.org/" : "/_/") +
-          ("api/v3/search/?q=" + projstr + "+" + encodeURIComponent(str));
+          ("api/v3/search/?q=" + projstr + "+" + encodeURIComponent(str)) +
+          (_rtdVersion ? "&version=" + encodeURIComponent(_rtdVersion) : "");
       }
       console.info("Getting " + url);
       fetch(url, {})

--- a/src/sunpy_sphinx_theme/theme/sunpy/static/js/rtd_enhanced_search.js
+++ b/src/sunpy_sphinx_theme/theme/sunpy/static/js/rtd_enhanced_search.js
@@ -34,14 +34,25 @@
 
 */
 /*jshint esversion: 6 */
-// Capture the current RTD version so search results stay on the version
-// the user is reading. Without this, the v3 search API defaults to the
+// Capture the current RTD project and version so search results stay on the
+// version the user is reading. Without this, the v3 search API defaults to the
 // project's default version (usually stable) and results link elsewhere.
+let _rtdProject = null;
 let _rtdVersion = null;
 document.addEventListener("readthedocs-addons-data-ready", function (event) {
   try {
-    _rtdVersion = event.detail.data().versions.current.slug;
+    const data = event.detail.data();
+    // Pull request previews are external versions and are not indexed. Pinning
+    // search to one would therefore return no results at all.
+    if (data.versions.current.type === "external") {
+      _rtdProject = null;
+      _rtdVersion = null;
+      return;
+    }
+    _rtdProject = data.projects.current.slug;
+    _rtdVersion = data.versions.current.slug;
   } catch (e) {
+    _rtdProject = null;
     _rtdVersion = null;
   }
 });
@@ -252,6 +263,13 @@ document.addEventListener("readthedocs-addons-data-ready", function (event) {
       form.classList.add("loading");
 
       let projstr = this.projectorder
+        .map(function (slug) {
+          // Only the project being read shares its current version. Other
+          // projects in this cross-project search keep their own defaults.
+          return _rtdProject && _rtdVersion && slug === _rtdProject
+            ? slug + "/" + _rtdVersion
+            : slug;
+        })
         .join("+project:")
         .replace(new RegExp("^" + config.all + "[s+]"), "");
       let url;
@@ -260,8 +278,7 @@ document.addEventListener("readthedocs-addons-data-ready", function (event) {
       } else {
         url =
           (debug ? "https://corsproxy.io/?https://readthedocs.org/" : "/_/") +
-          ("api/v3/search/?q=" + projstr + "+" + encodeURIComponent(str)) +
-          (_rtdVersion ? "&version=" + encodeURIComponent(_rtdVersion) : "");
+          ("api/v3/search/?q=" + projstr + "+" + encodeURIComponent(str));
       }
       console.info("Getting " + url);
       fetch(url, {})

--- a/src/sunpy_sphinx_theme/theme/sunpy/static/js/rtd_enhanced_search.js
+++ b/src/sunpy_sphinx_theme/theme/sunpy/static/js/rtd_enhanced_search.js
@@ -37,25 +37,35 @@
 // Capture the current RTD project and version so search results stay on the
 // version the user is reading. Without this, the v3 search API defaults to the
 // project's default version (usually stable) and results link elsewhere.
-let _rtdProject = null;
-let _rtdVersion = null;
-document.addEventListener("readthedocs-addons-data-ready", function (event) {
+let _rtdSearchContext = null;
+
+function updateRtdSearchContext(eventData) {
   try {
-    const data = event.detail.data();
+    const data = eventData.data();
+    const project = data.projects.current.slug;
+    const version = data.versions.current;
+
     // Pull request previews are external versions and are not indexed. Pinning
     // search to one would therefore return no results at all.
-    if (data.versions.current.type === "external") {
-      _rtdProject = null;
-      _rtdVersion = null;
+    if (!project || !version.slug || version.type === "external") {
+      _rtdSearchContext = null;
       return;
     }
-    _rtdProject = data.projects.current.slug;
-    _rtdVersion = data.versions.current.slug;
+
+    _rtdSearchContext = { project: project, version: version.slug };
   } catch (e) {
-    _rtdProject = null;
-    _rtdVersion = null;
+    _rtdSearchContext = null;
   }
+}
+
+document.addEventListener("readthedocs-addons-data-ready", function (event) {
+  updateRtdSearchContext(event.detail);
 });
+
+// This script is loaded asynchronously, so the event may have already fired.
+if (window.ReadTheDocsEventData !== undefined) {
+  updateRtdSearchContext(window.ReadTheDocsEventData);
+}
 
 (function (root) {
   function ready(fn) {
@@ -263,15 +273,17 @@ document.addEventListener("readthedocs-addons-data-ready", function (event) {
       form.classList.add("loading");
 
       let projstr = this.projectorder
-        .map(function (slug) {
+        .filter((project) => project !== config.all)
+        .map((project) => {
           // Only the project being read shares its current version. Other
           // projects in this cross-project search keep their own defaults.
-          return _rtdProject && _rtdVersion && slug === _rtdProject
-            ? slug + "/" + _rtdVersion
-            : slug;
+          if (_rtdSearchContext && project === _rtdSearchContext.project) {
+            return "project:" + project + "/" + _rtdSearchContext.version;
+          }
+
+          return "project:" + project;
         })
-        .join("+project:")
-        .replace(new RegExp("^" + config.all + "[s+]"), "");
+        .join("+");
       let url;
       if (page) {
         url = (debug ? "https://corsproxy.io/?" : "") + page;


### PR DESCRIPTION
Fixes #327.

Read the Docs v3 search defaults each project to its default version, usually `stable`. This caused searches from non-stable documentation builds to return links for `/en/stable/`.

This change reads the current project and version from the Read the Docs Addons data and pins only that project inside the search query using `project:<slug>/<version>`. Other projects remain on their own default versions.

External PR builds are not indexed, so they retain the existing unpinned search behavior. The Addons data is handled both when already available and  when delivered later by the `readthedocs-addons-data-ready` event.

This also affects projects using the SunPy theme, including Astropy through the Astropy unified theme. See astropy/astropy#19866.